### PR TITLE
Issue: please update the local communities

### DIFF
--- a/docs/help.rst
+++ b/docs/help.rst
@@ -35,5 +35,5 @@ The `hardware database <https://community.linuxmint.com/hardware/search>`_ is us
 
 Local communities
 -----------------
-
+ 
 To find help in your language, use the `Local Communities <https://www.linuxmint.com/links.php>`_.


### PR DESCRIPTION
Someone should have a look at the links on: https://www.linuxmint.com/links.php.
linuxmint.dk does not exist.
For Germany it would be good, to add https://ubuntuusers.de/. I think the wiki is bigger and more up to date than linuxmintusers.de.

P.S.: here is no issues section.