### PR TITLE
verify.rst — add instructions for using `shasum` as integrity checker

### DIFF
--- a/docs/verify.rst
+++ b/docs/verify.rst
@@ -38,6 +38,12 @@ To check the integrity of your local ISO file, generate its SHA256 sum and compa
 
     sha256sum -b yourfile.iso
 
+If you are running macOS, generate its SHA256 sum and compare it with the sum present in ``sha256sum.txt`` using the ``shasum`` command.
+
+.. code-block:: console
+
+    shasum -a 256 yourfile.iso
+
 .. hint::
     If you are using Windows follow the tutorial `How to verify the ISO image on Windows <https://forums.linuxmint.com/viewtopic.php?f=42&t=291093>`_.
 


### PR DESCRIPTION
Add instructions for using the `shasum` command to check the integrity of a downloaded `.iso` file.

`shasum` is included by default in macOS installs. `sha256sum` is not.

This addition extends the integrity check procedure instructions to essentially everyone who might download the Linux Mint `.iso` file.