### PR TITLE
Update etcher link in docs

### DIFF
--- a/docs/burn.rst
+++ b/docs/burn.rst
@@ -22,7 +22,7 @@ Select your USB device and click :guilabel:`Write`.
 In Windows, Mac OS, or other Linux distributions
 ````````````````````````````````````````````````
 
-Download `Etcher <https://www.balena.io/etcher/>`_, install it and run it.
+Download `Etcher <https://etcher.balena.io/>`_, install it and run it.
 
 .. figure:: images/etcher.png
     :width: 500px


### PR DESCRIPTION
The link provided in the docs sends me to a blank page. After googling the program, it seems like they changed etcher to be a subdomain of balena.io.