### PR TITLE
burn.rst now warns about losing USB files

### DIFF
--- a/docs/burn.rst
+++ b/docs/burn.rst
@@ -22,6 +22,9 @@ Select your USB device and click :guilabel:`Write`.
 In Windows, Mac OS, or other Linux distributions
 ````````````````````````````````````````````````
 
+.. warning::
+	Etcher will reformat your USB to the needed format, which will lose any existing files on it. Making a bootable USB is safest with an empty flashdrive
+
 Download `Etcher <https://etcher.balena.io/>`_, install it and run it.
 
 .. figure:: images/etcher.png


### PR DESCRIPTION
Etcher reformats the USB drive which can lead to file loss. This is now mentioned in a brief warning in the Etcher section.

In my case I made the mistake of making a badly worded google search so I thought it was safe; I'll need to be more careful next time!! But I imagine throwing this simple warning will save a few people some heartache. I was able to recover my files at least. 